### PR TITLE
Exits nicely now, make prompt global

### DIFF
--- a/cmd/keesh/keesh.go
+++ b/cmd/keesh/keesh.go
@@ -9,6 +9,9 @@ import (
 )
 
 func main() {
+
+	defer HandleExit()
+
 	// Load the runtime config (rc)
 	config.Runtime.Load()
 
@@ -16,11 +19,15 @@ func main() {
 		parser.ParseCommand(cmd)
 	}
 
-	p := prompt.NewPrompt()
+	p := prompt.P
 
 	for {
 		input := p.Show()
 		parser.ParseCommand(input)
 		fmt.Println()
 	}
+}
+
+func HandleExit() {
+	prompt.P.Term.Restore()
 }

--- a/internals/prompt/prompt.go
+++ b/internals/prompt/prompt.go
@@ -26,7 +26,7 @@ var (
 // Prompt represents a shell prompt.
 type Prompt struct {
 	reader  *bufio.Reader
-	term    *term.Term
+	Term    *term.Term
 	lastDir string
 }
 
@@ -58,7 +58,7 @@ func (p *Prompt) Show() (input string) {
 	fmt.Printf("%s %s\n%s ", segDir, segIcons, segArrow)
 
 	// Enter cbreak mode
-	p.term.SetCbreak()
+	p.Term.SetCbreak()
 
 	// TODO: refactor
 	for {
@@ -91,6 +91,7 @@ func (p *Prompt) Show() (input string) {
 		// CTRL + D
 		if b == 4 {
 			fmt.Println()
+			p.Term.Restore()
 			util.Exit()
 		}
 
@@ -130,13 +131,13 @@ func (p *Prompt) Show() (input string) {
 		}
 	}
 
-	p.term.Restore()
+	p.Term.Restore()
 	return strings.TrimSpace(input)
 }
 
 // NewPrompt instantiates a Prompt.
 func NewPrompt() *Prompt {
-	term, err := term.Open(os.Stdout.Name())
+	Term, err := term.Open(os.Stdout.Name())
 
 	if err != nil {
 		panic(err)
@@ -144,6 +145,9 @@ func NewPrompt() *Prompt {
 
 	return &Prompt{
 		reader: bufio.NewReader(os.Stdin),
-		term:   term,
+		Term:   Term,
 	}
 }
+
+//P Prompt used globally
+var P = NewPrompt()


### PR DESCRIPTION
De exit handler is nu gewoon een `defer` statement van main.
Eerst wou ik dat dit de exit handeling werd gedaan door de `util` package, daarom heb ik de moeite gedaan om de prompt te exporteren als een global variable, dan kunnen alle packages bij dezelfde prompt. Helaas werkt dit allemaal toch niet omdat (bijna) alleen "main" bij de prompt package kan anders krijg je een circular import. Daarom _moet_ nu dus ook al het handelen van de prompt of in de prompt package of in de main file gebeuren, en de exit handler kan dus niet in util/exit.go.
